### PR TITLE
Compatibilité Sylius 2 / PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,10 @@
   ],
   "license": "proprietary",
   "require": {
-    "php": ">=8.1",
-    "akki-team/sylius-settable-channel-plugin": "^1.0",
-    "akki-team/sylius-settable-locale-plugin": "^1.0",
-    "sylius/sylius": "^1.11 || ^1.12 || ^1.13 || ^1.14"
+    "php": "^8.2",
+    "akki-team/sylius-settable-channel-plugin": "^2.0",
+    "akki-team/sylius-settable-locale-plugin": "^2.0",
+    "sylius/sylius": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Préparation de la montée de version Sylius 2 du site uniqueheritage114.

## Changements
- **composer.json** : `sylius/sylius ^2.0`, `php ^8.2`, et les deux dépendances maison `akki-team/sylius-settable-channel-plugin` / `sylius-settable-locale-plugin` en `^2.0`.
- **Aucun changement de code** : les middlewares (Symfony Messenger), les stamps et le compiler pass restent valides en Symfony 7 / Sylius 2.

## Validation
Contre `sylius/sylius v2.2.6` (+ settable plugins `^2.0` montés en path repos), PHP 8.5 :
- résolution composer OK ;
- API présente : `RequestContext::setHost/setScheme`, `ChannelRepositoryInterface::findOneByCode`, `Core\Model\ChannelInterface::getHostname`, `SyliusPluginTrait` ;
- le `MessengerSettableContextMiddlewarePass` insère bien `set_channel`/`set_locale` **juste après `failed_message_processing_middleware`** dans une stack Messenger Symfony 7 reconstituée (ordre final vérifié).

## ⚠️ Dépendances / à faire après merge
- Nécessite la publication des `^2.0` de **sylius-settable-channel-plugin** (PR #2) et **sylius-settable-locale-plugin** (PR #1) sur les dépôts canoniques.
- Tagger **`2.0.0`** sur ce dépôt canonique après merge.